### PR TITLE
docs: add initial bot documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# metrolife-roleplay
-Il roleplay realistico su discord
+# MetroLife Roleplay
+
+Raccolta di bot Discord interconnessi che simulano la città di MetroLife.
+Ogni cartella contiene un bot con un singolo file di codice, un README e un changelog.
+
+## Bot disponibili
+- **Gelateria Vanillatte** (`gelateria/`) – gestione ordini gelato, magazzino pezzi e scontrini.
+- **MetroAziende** (`metroaziende/`) – organizzazioni, ruoli e contratti PDF.
+- **MetroDesk** (`metrodesks/`) – sportelli multi-tenant con transcript.
+- **MetroInventories** (`metroinventories/`) – inventari giocatori e definizione oggetti.
+- **MetroTrade** (`metrotrade/`) – scambi sicuri tra giocatori.
+- **Municipio Centrale** (`municipio/`) – tutorial, registrazione cittadini e documenti.
+
+Ogni bot espone comandi slash e condivide lo stesso database SQLite (`metrocity.db`).
+Consulta i README nelle rispettive cartelle per dettagli di setup e comandi.

--- a/gelateria/CHANGELOG.md
+++ b/gelateria/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog Gelateria
+
+## 0.1.0 - 2025-08-14
+- Documentazione iniziale

--- a/gelateria/README.md
+++ b/gelateria/README.md
@@ -1,0 +1,39 @@
+# Gelateria Vanillatte Bot
+
+Bot Discord per gestire la gelateria Vanillatte: ordini, cucina, vetrina, magazzino pezzi e scontrini.
+
+## Setup tecnico
+- Dipendenze: `discord.js`, `better-sqlite3`, `dotenv`
+- Avvio: `node gelateria.cjs`
+- Variabili d'ambiente: `DISCORD_TOKEN` (obbligatoria), `DB_PATH`, `APP_NAME`, `ORG_ID`
+
+## Comandi principali
+- `/magazzino-inizializza` – crea 50 slot magazzino
+- `/magazzino-area` – imposta area di uno slot
+- `/magazzino-deposita` – deposita pezzi dal tuo inventario
+- `/magazzino-stato` – mostra i 50 slot
+- `/magazzino-sposta` – sposta pezzi tra slot
+- `/magazzino-a-player` – trasferisce pezzi dal magazzino al player
+- `/player-a-magazzino` – trasferisce pezzi dal player al magazzino
+- `/lotti-ricevi` – riceve lotto sfuso
+- `/lotti-elenco` – elenca lotti con filtri
+- `/lotti-in-scadenza` – mostra lotti in scadenza (≤48h)
+- `/mappa-item` – mappa SKU gelateria a item inventario
+- `/menu` – visualizza menu
+- `/menu-pubblica` – pubblica menu con bottoni
+- `/ordina` – crea ticket cucina
+- `/cucina-coda` – mostra coda ordini
+- `/cucina-prendi` – prendi ticket (consuma ingredienti)
+- `/cucina-pronto` – segnala ticket pronto
+- `/cucina-autopronto` – pronto automatico dopo tempo
+- `/vetrina-livelli` – livelli della vetrina
+- `/vetrina-monta` – associa lotto a slot vetrina
+- `/economia-configura` – configura cap sfusi (staff RP)
+- `/tutorial` – guida rapida con embed
+- `/scontrino` – gestione scontrino (crea, aggiungi righe, emetti)
+
+## Tutorial giocatore
+1. Visualizza il menu con `/menu` e ordina con `/ordina`.
+2. Lo staff vede la coda con `/cucina-coda`, prende l'ordine con `/cucina-prendi` e consegna con `/cucina-pronto`.
+3. Per pagare, usa `/scontrino` per creare ed emettere lo scontrino.
+

--- a/metroaziende/CHANGELOG.md
+++ b/metroaziende/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog MetroAziende
+
+## 0.1.0 - 2025-08-14
+- Documentazione iniziale

--- a/metroaziende/README.md
+++ b/metroaziende/README.md
@@ -1,0 +1,31 @@
+# MetroAziende Bot
+
+Gestione organizzazioni cittadine: canali, ruoli, brand e contratti di assunzione.
+
+## Setup tecnico
+- Dipendenze: `discord.js`, `better-sqlite3`, `pdfkit`, `dotenv`
+- Avvio: `node metroaziende.cjs`
+- Variabili d'ambiente: `DISCORD_TOKEN` (obbligatoria), `DB_PATH`
+
+## Comandi principali
+- `/org-create` – crea una nuova organizzazione
+- `/org-channel-create` – crea canali per l'organizzazione
+- `/org-channel-edit` – modifica canali esistenti
+- `/org-channel-delete` – elimina un canale
+- `/org-role-style` – cambia nome/colore ruoli
+- `/org-role-setup` – imposta ruoli L1–L5
+- `/org-brand` – aggiorna colori e testi pubblici
+- `/org-info` – informazioni sull'organizzazione
+- `/org-roster` – elenco membri con livello
+- `/org-hire` – invia offerta di contratto
+- `/org-promote` – promuove un membro
+- `/org-demote` – retrocede un membro
+- `/org-fire` – licenzia un membro
+- `/contract-template` – gestisce template dei contratti
+- `/contract-sign` – il candidato accetta/rifiuta l'offerta
+
+## Uso giocatore
+1. Il direttore crea la struttura con `/org-create` e configura ruoli e canali.
+2. Per assumere un utente, usa `/org-hire` e attendi la firma tramite `/contract-sign`.
+3. Aggiorna il brand dell'azienda con `/org-brand`.
+

--- a/metrodesks/CHANGELOG.md
+++ b/metrodesks/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog MetroDesk
+
+## 0.1.0 - 2025-08-14
+- Documentazione iniziale

--- a/metrodesks/README.md
+++ b/metrodesks/README.md
@@ -1,0 +1,21 @@
+# MetroDesk Bot
+
+Sistema sportelli multi-tenant con transcript e gestione code.
+
+## Setup tecnico
+- Dipendenze: `discord.js`, `better-sqlite3`, `dotenv`
+- Avvio: `node metrodesk.cjs`
+- Variabili d'ambiente: `DISCORD_TOKEN` (obbligatoria), `DB_PATH`
+
+## Comandi principali
+- `/tenant-add` – registra un'azienda con categoria canali e ruoli
+- `/tenant-list` – elenca aziende registrate
+- `/tenant-remove` – rimuove un'azienda
+- `/desk-open` – apre uno sportello per un cliente
+- `/desk-close` – chiude lo sportello, salvando transcript
+
+## Uso giocatore
+1. Registra l'azienda con `/tenant-add`.
+2. Gli operatori aprono uno sportello con `/desk-open` e interagiscono con il cliente.
+3. Alla fine, chiudono con `/desk-close` per archiviare la conversazione.
+

--- a/metroinventories/CHANGELOG.md
+++ b/metroinventories/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog MetroInventories
+
+## 0.1.0 - 2025-08-14
+- Documentazione iniziale

--- a/metroinventories/README.md
+++ b/metroinventories/README.md
@@ -1,0 +1,23 @@
+# MetroInventories Bot
+
+Inventario a 10 slot con stack e oggetti unici, usato da altri servizi della città.
+
+## Setup tecnico
+- Dipendenze: `discord.js`, `better-sqlite3`, `dotenv`
+- Avvio: `node metroinventories.cjs`
+- Variabili d'ambiente: `DISCORD_TOKEN` (obbligatoria), `DB_PATH`
+
+## Comandi principali
+- `/inventario` – mostra il tuo inventario
+- `/item-upsert` – crea o modifica un tipo di oggetto
+- `/item-list` – elenco oggetti disponibili
+- `/inv-add` – aggiunge oggetti a un utente
+- `/inv-remove` – rimuove oggetti da un utente
+- `/inv-move` – sposta oggetti tra slot
+- `/inv-clear` – svuota l'inventario di un utente
+- `/use` – usa un oggetto (consumo o diminuzione durabilità)
+
+## Uso giocatore
+1. Gli admin definiscono gli oggetti con `/item-upsert`.
+2. Usa `/inventario` per vedere gli slot e `/use` per consumare o equipaggiare un oggetto.
+

--- a/metrotrade/CHANGELOG.md
+++ b/metrotrade/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog MetroTrade
+
+## 0.1.0 - 2025-08-14
+- Documentazione iniziale

--- a/metrotrade/README.md
+++ b/metrotrade/README.md
@@ -1,0 +1,24 @@
+# MetroTrade Bot
+
+Sistema di scambio sicuro tra due giocatori con meccanismo escrow a due fasi.
+
+## Setup tecnico
+- Dipendenze: `discord.js`, `better-sqlite3`, `dotenv`
+- Avvio: `node metrotrades.cjs`
+- Variabili d'ambiente: `DISCORD_TOKEN` (obbligatoria), `DB_PATH`
+
+## Comandi principali
+- `/trade-open` – avvia uno scambio con un utente
+- `/trade-offer-add` – offre oggetti nella trade
+- `/trade-offer-remove` – rimuove oggetti dall'offerta
+- `/trade-offer-list` – mostra le offerte correnti
+- `/trade-ready` – segnala che sei pronto
+- `/trade-confirm` – conferma lo scambio (all-or-nothing)
+- `/trade-cancel` – annulla la trade
+- `/trade-info` – informazioni sulla sessione di scambio
+
+## Uso giocatore
+1. Avvia la sessione con `/trade-open @utente`.
+2. Aggiungi gli oggetti con `/trade-offer-add` e quando sei pronto usa `/trade-ready`.
+3. Entrambi confermano con `/trade-confirm` per completare lo scambio.
+

--- a/municipio/CHANGELOG.md
+++ b/municipio/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog Municipio
+
+## 0.1.0 - 2025-08-14
+- Documentazione iniziale

--- a/municipio/README.md
+++ b/municipio/README.md
@@ -1,0 +1,22 @@
+# Municipio Centrale Bot
+
+Gestione tutorial iniziale, registrazione cittadini e rilascio documenti RP.
+
+## Setup tecnico
+- Dipendenze: `discord.js`, `better-sqlite3`, `dotenv`
+- Avvio: `node municipiocentrale.cjs`
+- Variabili d'ambiente: `DISCORD_TOKEN` (obbligatoria), `DB_PATH`
+
+## Comandi principali
+- `/tutorial-finish` – conclude il tutorial e raccoglie i dati anagrafici
+- `/municipio-self-register` – il cittadino si registra autonomamente
+- `/municipio-cert-check` – verifica se un utente è registrato
+- `/municipio-registra` – lo staff registra un cittadino
+- `/cdi-emetti` – emette il certificato di identità
+- `/trade-sim` – comando di test per scambi tra cittadino e dipendente
+
+## Uso giocatore
+1. Completa il tutorial con `/tutorial-finish` inserendo i dati RP.
+2. Se richiesto, usa `/municipio-self-register` per registrarti.
+3. Dopo l'approvazione, lo staff può emettere il tuo documento con `/cdi-emetti`.
+


### PR DESCRIPTION
## Summary
- document each Discord bot with setup and command guides
- add per-bot changelogs for future updates
- expand top-level README with bot overview

## Testing
- `node --check gelateria/gelateria.cjs`
- `node --check metroaziende/metroaziende.cjs`
- `node --check metrodesks/metrodesk.cjs`
- `node --check metroinventories/metroinventories.cjs` *(fails: Invalid or unexpected token)*
- `node --check municipio/municipiocentrale.cjs`
- `node --check metrotrade/metrotrades.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689e010d08308326a84c21e14b0efd01