### PR TITLE
Add simple gelato preparation flow

### DIFF
--- a/gelateria/CHANGELOG.md
+++ b/gelateria/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog Gelateria
 
+## 0.1.3 - 2025-08-14
+- Rimossi i comandi `/cucina-pronto` e `/cucina-autopronto`; documentazione aggiornata.
+
+## 0.1.2 - 2025-08-14
+- Aggiunti comandi `/magazzino-prendi` e `/cucina-gusto` per flusso rapido “acquisto → gelato consegnato”.
+
 ## 0.1.1 - 2025-08-14
 - Integrata libreria `inventory-core.cjs` per gestione inventario player e magazzino.
 

--- a/gelateria/README.md
+++ b/gelateria/README.md
@@ -14,6 +14,7 @@ Bot Discord per gestire la gelateria Vanillatte: ordini, cucina, vetrina, magazz
 - `/magazzino-deposita` – deposita pezzi dal tuo inventario
 - `/magazzino-stato` – mostra i 50 slot
 - `/magazzino-sposta` – sposta pezzi tra slot
+- `/magazzino-prendi` – preleva un cono o una coppetta
 - `/magazzino-a-player` – trasferisce pezzi dal magazzino al player
 - `/player-a-magazzino` – trasferisce pezzi dal player al magazzino
 - `/lotti-ricevi` – riceve lotto sfuso
@@ -25,8 +26,7 @@ Bot Discord per gestire la gelateria Vanillatte: ordini, cucina, vetrina, magazz
 - `/ordina` – crea ticket cucina
 - `/cucina-coda` – mostra coda ordini
 - `/cucina-prendi` – prendi ticket (consuma ingredienti)
-- `/cucina-pronto` – segnala ticket pronto
-- `/cucina-autopronto` – pronto automatico dopo tempo
+- `/cucina-gusto` – aggiunge un gusto al cono/coppetta (3 s per scoop)
 - `/vetrina-livelli` – livelli della vetrina
 - `/vetrina-monta` – associa lotto a slot vetrina
 - `/economia-configura` – configura cap sfusi (staff RP)
@@ -34,7 +34,8 @@ Bot Discord per gestire la gelateria Vanillatte: ordini, cucina, vetrina, magazz
 - `/scontrino` – gestione scontrino (crea, aggiungi righe, emetti)
 
 ## Tutorial giocatore
-1. Visualizza il menu con `/menu` e ordina con `/ordina`.
-2. Lo staff vede la coda con `/cucina-coda`, prende l'ordine con `/cucina-prendi` e consegna con `/cucina-pronto`.
-3. Per pagare, usa `/scontrino` per creare ed emettere lo scontrino.
+1. Preleva il contenitore con `/magazzino-prendi cono|coppetta`.
+2. Aggiungi i gusti uno alla volta con `/cucina-gusto <gusto>` (3 s per scoop).
+3. Scambia l'oggetto farcito con il cliente tramite MetroTrades.
+4. Se serve, emetti lo scontrino con `/scontrino` dopo lo scambio.
 

--- a/gelateria/agent.md
+++ b/gelateria/agent.md
@@ -8,7 +8,7 @@ Scopo: guida operativa per lo staff della gelateria su Discord (MetroLife City).
 	•	👮‍♂️ Admin RP (fuori azienda): setup iniziale, ricezione sfusi straordinaria, economia futura, mapping SKU↔item. Usano solo comandi amministrativi (non di servizio).
 	•	🧭 L1 Direttore / L2 Vice: coordinano turni, ricette, vetrina, controlli stock, scontrini.
 	•	👨‍🍳 L3 Capo Turno (Chef) / L4 Responsabile Banco: operatività completa (coda, servizio, vetrina, magazzino pezzi, scontrini).
-	•	🍦 L5 Gelataio: può “cucinare” (servire), cioè prendere ticket, preparare e segnare pronto; può usare lo scontrino.
+	•	🍦 L5 Gelataio: può “cucinare” (servire), cioè prendere ticket e preparare; può usare lo scontrino.
 
 Nota: setup/autogive rimangono agli Admin RP. La direzione e lo staff gestiscono solo l’operatività interna.
 
@@ -20,9 +20,8 @@ Nota: setup/autogive rimangono agli Admin RP. La direzione e lo staff gestiscono
 	3.	Presa in carico: /cucina-prendi ticket:<id>
 	•	Scala automaticamente pezzi (coppette, cucchiaini…) dal magazzino dell’org (qualsiasi area).
 	•	Scala scoop dai lotti sfusi in FEFO.
-	4.	Consegna al banco: /cucina-pronto ticket:<id> o /cucina-autopronto
-	•	Il bot mette nell’inventario del gelataio l’item con lo stesso nome del menu (es. coppetta_2g).
-	5.	Trade al cliente: il gelataio scambia l’item (pagamenti veri si integreranno con la Banca).
+	4.	Consegna al banco: scambia l’item con il cliente tramite MetroTrades.
+	5.	Se serve, emetti lo scontrino con `/scontrino`.
 
 ⸻
 


### PR DESCRIPTION
## Summary
- add `/magazzino-prendi` to fetch cones or cups and place them in inventory
- add `/cucina-gusto` to scoop flavors with 3s delay and fill the container
- remove `/cucina-pronto` and `/cucina-autopronto`; trade filled items directly
- document simplified order-to-delivery flow and update changelog

## Testing
- `node --check gelateria/gelateria.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689e0cc51ca48326975bc6304156edbe