### PR TITLE
Fix syntax error in Municipio bot

### DIFF
--- a/municipio/CHANGELOG.md
+++ b/municipio/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog Municipio
 
+## 0.2.1 - 2025-08-14
+- Corretto errore di sintassi nel bot del Municipio che bloccava l'avvio.
+
 ## 0.2.0 - 2025-02-14
 - Rimosso comando /trade-sim e adottata libreria MetroInventory condivisa.
 

--- a/municipio/municipiocentrale.cjs
+++ b/municipio/municipiocentrale.cjs
@@ -477,9 +477,6 @@ client.on('interactionCreate', async (i) => {
         .setDescription(`Consegnata a <@${target.id}> come item **cdi** (stato: VALID).`);
       return i.reply({ embeds:[emb], ephemeral:true });
     }
-      await addAudit(guildId, i.user.id, 'CERT_TRADE', to.id, { from: from.id, to: to.id, id_cert: payload.id_cert });
-      return i.reply({ embeds:[embOk('Trade simulato').setDescription(`Certificato trasferito da <@${from.id}> a <@${to.id}>.`)], ephemeral:true });
-    }
 
   } catch (err) {
     console.error('Interaction error:', err);


### PR DESCRIPTION
## Summary
- remove stray CERT_TRADE lines causing missing catch error in `municipiocentrale.cjs`
- update municipio changelog

## Testing
- `node --check municipio/municipiocentrale.cjs`
- `node municipio/municipiocentrale.cjs` *(fails: Manca DISCORD_TOKEN nel .env)*

------
https://chatgpt.com/codex/tasks/task_e_689e38240ac083268928154b2ac8fa2c